### PR TITLE
Fix not chached user bug

### DIFF
--- a/src/components/molecules/user_info/UserInfo.js
+++ b/src/components/molecules/user_info/UserInfo.js
@@ -9,7 +9,7 @@ require('./stylesheets/user_info.scss');
 
 class UserInfo extends React.Component {
   getUserProfile() {
-    return JSON.parse(localStorage.getItem('userProfile'));
+    return JSON.parse(localStorage.getItem('userProfile')) || {email:"",nickname:""};
   }
   render() {
 


### PR DESCRIPTION
raise error when user was not cached in localStorage.

Uncaught TypeError: Cannot read property 'email' of null
